### PR TITLE
Add autofollow_stats to HANDBOOK.md

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -271,6 +271,34 @@ curl -k -u testuser:testuser -XDELETE \
 -d'{"leader_alias":"leader-cluster", "name":"my-replication"}'
 ```
 
+## Check AutoFollow stats
+Stats for all AutoFollow tasks running on the follower cluster can be checked using `autofollow_stats`.
+
+```bash
+curl -k -u admin:admin -XGET "https://${FOLLOWER}/_plugins/_replication/autofollow_stats" 
+{
+"num_success_start_replication" : 16,
+  "num_failed_start_replication" : 0,
+  "num_failed_leader_calls" : 0,
+  "failed_indices" : [
+    "leader-08"
+  ],
+  "autofollow_stats" : [
+    {
+      "name" : "first_rule",
+      "pattern" : "leader-*",
+      "num_success_start_replication" : 16,
+      "num_failed_start_replication" : 0,
+      "num_failed_leader_calls" : 0,
+      "failed_indices" : [
+        "leader-08"
+      ],
+      "last_execution_time" : 1679640596573
+    }
+  ]
+}
+```
+
 ## Check ongoing replication tasks
 
 Until a status API is added, you can check ongoing replication via the tasks API.


### PR DESCRIPTION
Currently HANDBOOK.md does not have autofollow_stats example.

### Description
Currently HANDBOOK.md does not have autofollow_stats example.

added the command and the output for autofollow_stats
```bash
curl -k -u admin:admin -XGET "https://${FOLLOWER}/_plugins/_replication/autofollow_stats" 
{
"num_success_start_replication" : 16,
  "num_failed_start_replication" : 0,
  "num_failed_leader_calls" : 0,
  "failed_indices" : [
    "leader-08"
  ],
  "autofollow_stats" : [
    {
      "name" : "first_rule",
      "pattern" : "leader-*",
      "num_success_start_replication" : 16,
      "num_failed_start_replication" : 0,
      "num_failed_leader_calls" : 0,
      "failed_indices" : [
        "leader-08"
      ],
      "last_execution_time" : 1679640596573
    }
  ]
}
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
